### PR TITLE
Fixing kernelspec configuration to octave

### DIFF
--- a/Notebooks/MRI Contrast.ipynb
+++ b/Notebooks/MRI Contrast.ipynb
@@ -809,9 +809,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "Octave",
+   "language": "octave",
+   "name": "octave"
   },
   "language_info": {
    "file_extension": ".m",
@@ -830,8 +830,8 @@
     }
    ],
    "mimetype": "text/x-octave",
-   "name": "python",
-   "version": "3.7.3"
+   "name": "octave",
+   "version": "5.1.0"
   },
   "vscode": {
    "interpreter": {

--- a/Notebooks/MRI Signal Equation.ipynb
+++ b/Notebooks/MRI Signal Equation.ipynb
@@ -426,9 +426,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "Octave",
+   "language": "octave",
+   "name": "octave"
   },
   "language_info": {
    "file_extension": ".m",
@@ -447,8 +447,8 @@
     }
    ],
    "mimetype": "text/x-octave",
-   "name": "python",
-   "version": "3.7.3"
+   "name": "octave",
+   "version": "5.1.0"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Hi Dr Larson, this is really a great resource. I noticed a couple Jupyter notebooks that by default launch in Python kernel in Binder, which needs to manually change to Octave in order to run without error message. Therefore, this PR is an attempt to fix that minor issue by configuring Octave as default. Very best, Kai (MSBI 14')